### PR TITLE
Fix crash of progress page - Use `weight` instead of `max_score`

### DIFF
--- a/drag_and_drop/drag_and_drop.py
+++ b/drag_and_drop/drag_and_drop.py
@@ -11,7 +11,7 @@ from lxml import etree
 from xml.etree import ElementTree as ET
 
 from xblock.core import XBlock
-from xblock.fields import Scope, String, Integer, Dict
+from xblock.fields import Scope, String, Dict, Float
 from xblock.fragment import Fragment
 
 from StringIO import StringIO
@@ -37,9 +37,9 @@ class DragAndDropBlock(XBlock):
         default="Drag and Drop"
     )
 
-    max_score = Integer(
-        display_name="Max Score",
-        help="This is the score that the user receives when he/she successfully completes the problem",
+    weight = Float(
+        display_name="Weight",
+        help="This is the maximum score that the user receives when he/she successfully completes the problem",
         scope=Scope.settings,
         default=1
     )
@@ -159,8 +159,8 @@ class DragAndDropBlock(XBlock):
 
         draggable_target_class = 'draggable-target' if len(targets) > 1 else 'draggable-target-full-width'
 
-        max_score_string = '({0} Point{1})'.format(self.max_score,
-            's' if self.max_score > 1 else '') if self.max_score else ''
+        max_score_string = '({0} Point{1})'.format(int(self.weight),
+            's' if self.weight > 1 else '') if self.weight else ''
 
         context = {
             'title': self.display_name,
@@ -214,7 +214,7 @@ class DragAndDropBlock(XBlock):
             except:
                 max_score = 1
 
-        self.max_score = max_score
+        self.weight = max_score
 
         try:
             etree.parse(StringIO(xml_content))
@@ -283,8 +283,8 @@ class DragAndDropBlock(XBlock):
             # NOTE, we don't support partial credit
             try:
                 self.runtime.publish(self, 'grade', {
-                    'value': self.max_score,
-                    'max_value': self.max_score,
+                    'value': self.weight,
+                    'max_value': self.weight,
                 })
             except NotImplementedError:
                 # Note, this publish method is unimplemented in Studio runtimes, so

--- a/drag_and_drop/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop/templates/html/drag_and_drop_edit.html
@@ -12,7 +12,7 @@
       <li class="field comp-setting-entry is-set">
           <div class="wrapper-comp-setting">
             <label class="label setting-label" for="edit_max_score">Max Score</label>
-            <input class="input setting-input edit-max-score" id="edit_max_score" value="{{ self.max_score }}" type="text">
+            <input class="input setting-input edit-max-score" id="edit_max_score" value="{{ self.weight }}" type="text">
           </div>
           <span class="tip setting-help">The maximum number of points awarded to this problem</span>
       </li>


### PR DESCRIPTION
FYI @chrisndodge - using max_score was making the progress page crash with:

```
Apr 25 12:18:59 ip-10-0-11-19 [service_variant=lms][django.request][env:sandbox] ERROR [ip-10-0-11-19 1121] [base.py:215] - Internal Server Error: /courses/Demo/DM01/2014/progress
Traceback (most recent call last):
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
response = callback(request, *callback_args, **callback_kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 20, in _wrapped_view
return view_func(request, *args, **kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/cache.py", line 75, in _cache_controlled
response = viewfunc(request, *args, **kw)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/transaction.py", line 224, in inner
return func(*args, **kwargs)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views.py", line 637, in progress
return _progress(request, course_id, student_id)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views.py", line 667, in _progress
courseware_summary = grades.progress_summary(student, request, course)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/transaction.py", line 224, in inner
return func(*args, **kwargs)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/grades.py", line 315, in progress_summary
return _progress_summary(student, request, course)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/grades.py", line 378, in _progress_summary
course_id, student, module_descriptor, module_creator, scores_cache=submissions_scores
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/grades.py", line 471, in get_score
total = problem.max_score()
TypeError: 'int' object is not callable
```
